### PR TITLE
Nanoseconds

### DIFF
--- a/timemilli.go
+++ b/timemilli.go
@@ -3,9 +3,9 @@ package timemilli
 import "time"
 
 const millisInSecond = 1000
-const nsInSecond = 1000000
+const nsInMilliSecond = 1000_000
 
 // Converts Unix Epoch from milliseconds to time.Time
 func FromUnixMilli(ms int64) time.Time {
-	return time.Unix(ms/int64(millisInSecond), (ms%int64(millisInSecond))*int64(nsInSecond))
+	return time.Unix(ms/int64(millisInSecond), (ms%int64(millisInSecond))*int64(nsInMilliSecond))
 }

--- a/timemilli_test.go
+++ b/timemilli_test.go
@@ -9,7 +9,7 @@ func BenchmarkMult(b *testing.B) {
 	var inp int64
 	inp = 1542810446506
 	for n := 0; n < b.N; n++ {
-		time.Unix(0, inp*int64(time.Nanosecond))
+		time.Unix(0, inp*int64(nsInMilliSecond))
 	}
 }
 
@@ -17,7 +17,7 @@ func BenchmarkDiv(b *testing.B) {
 	var ms int64
 	ms = 1542810446506
 	for n := 0; n < b.N; n++ {
-		time.Unix(ms/int64(millisInSecond), (ms%int64(millisInSecond))*int64(time.Nanosecond))
+		time.Unix(ms/int64(millisInSecond), (ms%int64(millisInSecond))*int64(nsInMilliSecond))
 	}
 }
 


### PR DESCRIPTION
Hi, thanks for this module. It helped me out as a Go noob and needing to process a file containing thousands of millisecond timestamp values.

Reading through the code and tests is there any particular reason you use time.Nanosecond in the tests rather the variable from the package? Part of this pull request changes the tests to use the variable as it represents the actual calculation whereas time.Nanosecond returns 1. If there is a reason for using it then please ignore this change.

I have also updated the name of the variable in the package to better reflect what the value is.